### PR TITLE
Fix typo in FAQ about mojmap and reobf

### DIFF
--- a/pages/docs/faq.md
+++ b/pages/docs/faq.md
@@ -22,7 +22,7 @@ You can refer to [YouHaveTrouble's guide](https://github.com/YouHaveTrouble/mine
 Found an incompatible plugin? [Report it here](https://github.com/Winds-Studio/Leaf/issues/new/choose)!
 
 ## ❓ · What's the difference between mojmap and reobf? Which should I use?
-They use different mappings. Mojmap uses mojang mapping, and reobf uses spigot mapping. If two jar files provided, one ends with mojang,
+They use different mappings. Mojmap uses mojang mapping, and reobf uses spigot mapping. If two jar files provided, one ends with mojmap,
 and another is reobf, you should use the one ends with mojmap.
 
 ## ❓ · How can I support the project?


### PR DESCRIPTION
This pull request makes a minor correction to the documentation in the FAQ. It fixes a typo in the description of the "mojmap" mapping to accurately match the filename ending.

- Corrected the mapping description in `pages/docs/faq.md` to state that the Mojang mapping jar ends with "mojmap" instead of "mojang".