### PR TITLE
refactor(theme): align download status colors with semantic palette

### DIFF
--- a/.vitepress/theme/components/download/statusColors.scss
+++ b/.vitepress/theme/components/download/statusColors.scss
@@ -1,15 +1,15 @@
 * {
     &.status-dev {
-        --status-color-1: var(--vp-c-danger-1);
-        --status-color-2: var(--vp-c-danger-2);
-        --status-color-3: var(--vp-c-danger-3);
-        --status-color-soft: var(--vp-c-danger-soft);
+        --status-color-1: var(--vp-c-indigo-1);
+        --status-color-2: var(--vp-c-indigo-2);
+        --status-color-3: var(--vp-c-indigo-3);
+        --status-color-soft: var(--vp-c-indigo-soft);
     }
     &.status-stable {
-        --status-color-1: var(--vp-c-brand-1);
-        --status-color-2: var(--vp-c-brand-2);
-        --status-color-3: var(--vp-c-brand-3);
-        --status-color-soft: var(--vp-c-brand-soft);
+        --status-color-1: var(--vp-c-success-1);
+        --status-color-2: var(--vp-c-success-2);
+        --status-color-3: var(--vp-c-success-3);
+        --status-color-soft: var(--vp-c-success-soft);
     }
     &.status-eol {
         --status-color-1: var(--vp-c-warning-1);
@@ -18,7 +18,7 @@
         --status-color-soft: var(--vp-c-warning-soft);
     }
     &.status-dead {
-        --status-color-1: var(--vp-c-caution-1);
+        --status-color-1: var(--vp-c-danger-1);
         --status-color-2: var(--vp-c-danger-2);
         --status-color-3: var(--vp-c-danger-3);
         --status-color-soft: var(--vp-c-danger-soft);


### PR DESCRIPTION
<img width="249" height="390" alt="image" src="https://github.com/user-attachments/assets/b8bf9279-322a-42b4-b737-24f961956186" />
